### PR TITLE
Sort isometric draw order by screen-space depth

### DIFF
--- a/src/client/mapview.cpp
+++ b/src/client/mapview.cpp
@@ -46,6 +46,8 @@
 #include <framework/util/extras.h>
 #include <framework/core/adaptiverenderer.h>
 
+#include <algorithm>
+
 MapView::MapView()
 {
     m_lockedFirstVisibleFloor = -1;
@@ -160,10 +162,22 @@ void MapView::drawFloor(short floor, const Position& cameraPosition, const TileP
     auto& tiles = m_cachedVisibleTiles[floor];
     size_t lightFloorStart = m_lightView ? m_lightView->size() : 0;
 
+    std::vector<std::pair<TilePtr, Point>> drawList;
+    drawList.reserve(tiles.size());
+    for (auto& tile : tiles) {
+        drawList.emplace_back(tile, transformPositionTo2D(tile->getPosition(), cameraPosition));
+    }
+
+    // Sort tiles by projected screen-space Y so the isometric pipeline draws lower tiles last.
+    std::stable_sort(drawList.begin(), drawList.end(), [](const auto& a, const auto& b) {
+        return a.second.y < b.second.y;
+    });
+
     // light
     if (m_lightView) {
-        for (auto& tile : tiles) {
-            Point tileDrawPos = transformPositionTo2D(tile->getPosition(), cameraPosition);
+        for (const auto& entry : drawList) {
+            const TilePtr& tile = entry.first;
+            const Point& tileDrawPos = entry.second;
             ItemPtr ground = tile->getGround();
             if (ground && ground->isGround() && !ground->isTranslucent()) {
                 m_lightView->setFieldBrightness(tileDrawPos, lightFloorStart, 0);
@@ -173,13 +187,15 @@ void MapView::drawFloor(short floor, const Position& cameraPosition, const TileP
 
     if (g_game.getFeature(Otc::GameMapDrawGroundFirst)) {
         // ground
-        for (auto& tile : tiles) {
-            Point tileDrawPos = transformPositionTo2D(tile->getPosition(), cameraPosition);
+        for (const auto& entry : drawList) {
+            const TilePtr& tile = entry.first;
+            const Point& tileDrawPos = entry.second;
             tile->drawGround(tileDrawPos, m_lightView.get());
         }
         // bottom, creatures, top
-        for (auto& tile : tiles) {
-            Point tileDrawPos = transformPositionTo2D(tile->getPosition(), cameraPosition);
+        for (const auto& entry : drawList) {
+            const TilePtr& tile = entry.first;
+            const Point& tileDrawPos = entry.second;
 
             tile->drawBottom(tileDrawPos, m_lightView.get());
 
@@ -193,8 +209,9 @@ void MapView::drawFloor(short floor, const Position& cameraPosition, const TileP
         }
     } else {
         // ground, bottom, creatures, top
-        for (auto& tile : tiles) {
-            Point tileDrawPos = transformPositionTo2D(tile->getPosition(), cameraPosition);
+        for (const auto& entry : drawList) {
+            const TilePtr& tile = entry.first;
+            const Point& tileDrawPos = entry.second;
 
             if (m_lightView) {
                 ItemPtr ground = tile->getGround();
@@ -251,6 +268,11 @@ void MapView::drawMapForeground(const Rect& rect)
         p += rect.topLeft();
         creatures.push_back(std::make_pair(creature, p));
     }
+
+    // Sort by screen-space Y so the isometric pipeline respects creature depth against terrain.
+    std::stable_sort(creatures.begin(), creatures.end(), [](const auto& a, const auto& b) {
+        return a.second.y < b.second.y;
+    });
 
     for (auto& c : creatures) {
         int flags = Otc::DrawIcons;


### PR DESCRIPTION
## Summary
- sort cached floor tiles by projected screen-space Y before rendering so isometric depth is respected
- order creatures in the foreground draw pass using their screen-space Y
- document the screen-space ordering decisions for the isometric pipeline

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dab3861c3c8330abca5208f77ce619