### PR TITLE
Adopt isometric projection in map view

### DIFF
--- a/src/client/lightview.cpp
+++ b/src/client/lightview.cpp
@@ -36,9 +36,15 @@ void LightView::addLight(const Point& pos, uint8_t color, uint8_t intensity)
     m_lights.push_back(Light{ pos, color, intensity });
 }
 
-void LightView::setFieldBrightness(const Point& pos, size_t start, uint8_t color)
+void LightView::setFieldBrightness(const Point& tileIndex, size_t start, uint8_t color)
 {
-    size_t index = (pos.y / g_sprites.spriteSize()) * m_mapSize.width() + (pos.x / g_sprites.spriteSize());
+    if (tileIndex.x < 0 || tileIndex.y < 0)
+        return;
+
+    if (tileIndex.x >= m_mapSize.width() || tileIndex.y >= m_mapSize.height())
+        return;
+
+    size_t index = static_cast<size_t>(tileIndex.y) * m_mapSize.width() + static_cast<size_t>(tileIndex.x);
     if (index >= m_tiles.size()) return;
     m_tiles[index].start = start;
     m_tiles[index].color = color;

--- a/src/client/lightview.h
+++ b/src/client/lightview.h
@@ -48,7 +48,7 @@ public:
         return addLight(pos, light.color, light.intensity);
     }
     void addLight(const Point& pos, uint8_t color, uint8_t intensity);
-    void setFieldBrightness(const Point& pos, size_t start, uint8_t color);
+    void setFieldBrightness(const Point& tileIndex, size_t start, uint8_t color);
     size_t size() { return m_lights.size(); }
 
     void draw() override;

--- a/src/client/mapview.cpp
+++ b/src/client/mapview.cpp
@@ -45,6 +45,7 @@
 
 #include <framework/util/extras.h>
 #include <framework/core/adaptiverenderer.h>
+#include <cmath>
 
 MapView::MapView()
 {
@@ -53,6 +54,7 @@ MapView::MapView()
     m_cachedLastVisibleFloor = 7;
     m_minimumAmbientLight = 0;
     m_optimizedSize = Size(g_map.getAwareRange().horizontal(), g_map.getAwareRange().vertical()) * g_sprites.spriteSize();
+    m_zOffset = g_sprites.spriteSize() / 2.f;
 
     setVisibleDimension(Size(15, 11));
 }
@@ -163,10 +165,13 @@ void MapView::drawFloor(short floor, const Position& cameraPosition, const TileP
     // light
     if (m_lightView) {
         for (auto& tile : tiles) {
-            Point tileDrawPos = transformPositionTo2D(tile->getPosition(), cameraPosition);
+            const Position& tilePosition = tile->getPosition();
             ItemPtr ground = tile->getGround();
             if (ground && ground->isGround() && !ground->isTranslucent()) {
-                m_lightView->setFieldBrightness(tileDrawPos, lightFloorStart, 0);
+                const Point tileIndex(
+                    m_virtualCenterOffset.x + (tilePosition.x - cameraPosition.x),
+                    m_virtualCenterOffset.y + (tilePosition.y - cameraPosition.y));
+                m_lightView->setFieldBrightness(tileIndex, lightFloorStart, 0);
             }
         }
     }
@@ -194,12 +199,16 @@ void MapView::drawFloor(short floor, const Position& cameraPosition, const TileP
     } else {
         // ground, bottom, creatures, top
         for (auto& tile : tiles) {
-            Point tileDrawPos = transformPositionTo2D(tile->getPosition(), cameraPosition);
+            const Position& tilePosition = tile->getPosition();
+            Point tileDrawPos = transformPositionTo2D(tilePosition, cameraPosition);
 
             if (m_lightView) {
                 ItemPtr ground = tile->getGround();
                 if (ground && ground->isGround() && !ground->isTranslucent()) {
-                    m_lightView->setFieldBrightness(tileDrawPos, lightFloorStart, 0);
+                    const Point tileIndex(
+                        m_virtualCenterOffset.x + (tilePosition.x - cameraPosition.x),
+                        m_virtualCenterOffset.y + (tilePosition.y - cameraPosition.y));
+                    m_lightView->setFieldBrightness(tileIndex, lightFloorStart, 0);
                 }
             }
 
@@ -633,8 +642,36 @@ int MapView::calcLastVisibleFloor()
 }
 
 Point MapView::transformPositionTo2D(const Position& position, const Position& relativePosition) {
-    return Point((m_virtualCenterOffset.x + (position.x - relativePosition.x) - (relativePosition.z - position.z)) * g_sprites.spriteSize(),
-        (m_virtualCenterOffset.y + (position.y - relativePosition.y) - (relativePosition.z - position.z)) * g_sprites.spriteSize());
+    const float tileWidth = static_cast<float>(g_sprites.spriteSize());
+    const float tileHeight = static_cast<float>(g_sprites.spriteSize());
+    const float halfTileWidth = tileWidth / 2.f;
+    const float halfTileHeight = tileHeight / 2.f;
+
+    const float dx = static_cast<float>(position.x - relativePosition.x);
+    const float dy = static_cast<float>(position.y - relativePosition.y);
+    const float dz = static_cast<float>(position.z - relativePosition.z);
+
+    // Convert the camera-relative tile position into isometric coordinates. The virtual
+    // center keeps the camera tile anchored while `(x - y)` and `(x + y)` project the
+    // cartesian grid onto an isometric diamond.
+    const float virtualX = static_cast<float>(m_virtualCenterOffset.x) + dx;
+    const float virtualY = static_cast<float>(m_virtualCenterOffset.y) + dy;
+
+    const float isoX = (virtualX - virtualY) * halfTileWidth;
+    const float isoY = (virtualX + virtualY) * halfTileHeight;
+
+    const float centerIsoX = (static_cast<float>(m_virtualCenterOffset.x) - static_cast<float>(m_virtualCenterOffset.y)) * halfTileWidth;
+    const float centerIsoY = (static_cast<float>(m_virtualCenterOffset.x) + static_cast<float>(m_virtualCenterOffset.y)) * halfTileHeight;
+
+    float screenX = isoX - centerIsoX + static_cast<float>(m_virtualCenterOffset.x) * tileWidth;
+    float screenY = isoY - centerIsoY + static_cast<float>(m_virtualCenterOffset.y) * tileHeight;
+
+    // Shift from the diamond center so the sprite origin lines up with our 2D coordinates
+    // and pull deeper floors upward in screen space using the configurable vertical z-offset.
+    screenX -= halfTileWidth;
+    screenY -= dz * m_zOffset;
+
+    return Point(static_cast<int>(std::lround(screenX)), static_cast<int>(std::lround(screenY)));
 }
 
 

--- a/src/client/mapview.h
+++ b/src/client/mapview.h
@@ -113,6 +113,9 @@ public:
     void setFloorFading(int value) { m_floorFading = value; }
     void setCrosshair(const std::string& file);
 
+    void setZOffset(float offset) { m_zOffset = offset; }
+    float getZOffset() const { return m_zOffset; }
+
     //void setShader(const PainterShaderProgramPtr& shader, float fadein, float fadeout);
     //PainterShaderProgramPtr getShader() { return m_shader; }
 
@@ -166,6 +169,7 @@ private:
     float m_minimumAmbientLight;
     std::unique_ptr<LightView> m_lightView;
     TexturePtr m_lightTexture;
+    float m_zOffset = 0.f;
 };
 
 #endif


### PR DESCRIPTION
## Summary
- switch the map projection math to an isometric transform that derives tile dimensions from the sprite size
- expose a configurable zOffset that vertically separates floors in screen space
- update light sampling to index tiles in the new coordinate system

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dab38247bc83309a4b0857112c3554