### PR TITLE
Add batched creature ground shadow rendering

### DIFF
--- a/src/client/creature.cpp
+++ b/src/client/creature.cpp
@@ -44,6 +44,10 @@
 
 #include <framework/util/stats.h>
 #include <framework/util/extras.h>
+#include <framework/util/size.h>
+
+#include <algorithm>
+#include <cmath>
 
 std::array<double, Otc::LastSpeedFormula> Creature::m_speedFormula = { -1,-1,-1 };
 
@@ -101,6 +105,25 @@ void Creature::draw(const Point& dest, bool animate, LightView* lightView)
 
     if (m_outfit.getCategory() != ThingCategoryCreature)
         animationOffset -= getDisplacement();
+
+    const ThingTypePtr& type = rawGetThingType();
+    if (type && m_outfit.getCategory() == ThingCategoryCreature) {
+        const Point shadowBase = dest - jumpOffset + animationOffset - getDisplacement();
+        const int typeWidth = std::max(1, type->getWidth());
+        const int typeHeight = std::max(1, type->getHeight());
+        const float footprintWidth = static_cast<float>(typeWidth * sprSize);
+        const float footprintHeight = static_cast<float>(typeHeight * sprSize);
+        const float footprintTiles = static_cast<float>(std::max(typeWidth, typeHeight));
+        const float shadowWidth = footprintWidth * 0.9f;
+        const float shadowHeight = footprintHeight * (0.35f + 0.1f * (footprintTiles - 1.f));
+        const float opacity = std::clamp(0.45f + 0.15f * (footprintTiles - 1.f), 0.35f, 0.75f);
+        const int shadowAlpha = std::clamp<int>(static_cast<int>(std::round(opacity * 255.f)), 0, 255);
+        const PointF shadowCenter(shadowBase.x + footprintWidth / 2.f, shadowBase.y + footprintHeight / 2.f);
+
+        // Soft ground shadow ties the creature to the map; the shared ellipse scales and darkens with the footprint
+        // so bigger sprites cast broader, slightly stronger silhouettes without breaking batching.
+        g_drawQueue->addGroundShadow(shadowCenter, SizeF(shadowWidth, shadowHeight), Color(0, 0, 0, shadowAlpha));
+    }
 
     size_t drawQueueSize = g_drawQueue->size();
     m_outfit.draw(dest - jumpOffset + animationOffset, m_walking ? m_walkDirection : m_direction, m_walkAnimationPhase, true, lightView);

--- a/src/framework/graphics/drawqueue.cpp
+++ b/src/framework/graphics/drawqueue.cpp
@@ -1,4 +1,5 @@
 #include <stack>
+#include <cmath>
 #include <framework/graphics/drawqueue.h>
 #include <framework/graphics/painter.h>
 #include <framework/graphics/atlas.h>
@@ -12,6 +13,62 @@
 #include <client/outfit.h>
 
 std::shared_ptr<DrawQueue> g_drawQueue;
+
+namespace {
+constexpr int kShadowSegments = 24;
+constexpr float kShadowBaseRadius = 1024.f;
+constexpr float kShadowBaseDiameter = kShadowBaseRadius * 2.f;
+constexpr float kPi = 3.14159265358979323846f;
+
+std::shared_ptr<CoordsBuffer> createGroundShadowCoords()
+{
+    auto coords = std::make_shared<CoordsBuffer>();
+    const Point center(0, 0);
+    for (int i = 0; i < kShadowSegments; ++i) {
+        const float angle1 = (static_cast<float>(i) / kShadowSegments) * 2.f * kPi;
+        const float angle2 = (static_cast<float>(i + 1) / kShadowSegments) * 2.f * kPi;
+        const Point p1(static_cast<int>(std::lround(std::cos(angle1) * kShadowBaseRadius)),
+            static_cast<int>(std::lround(std::sin(angle1) * kShadowBaseRadius)));
+        const Point p2(static_cast<int>(std::lround(std::cos(angle2) * kShadowBaseRadius)),
+            static_cast<int>(std::lround(std::sin(angle2) * kShadowBaseRadius)));
+        coords->addTriangle(center, p1, p2);
+    }
+    coords->cache();
+    return coords;
+}
+
+const std::shared_ptr<CoordsBuffer>& groundShadowCoords()
+{
+    static const std::shared_ptr<CoordsBuffer> coords = createGroundShadowCoords();
+    return coords;
+}
+}
+
+DrawQueueItemGroundShadow::DrawQueueItemGroundShadow(const std::shared_ptr<CoordsBuffer>& coordsBuffer, const PointF& center, const SizeF& size, const Color& color)
+    : DrawQueueItem(nullptr, color),
+    m_coordsBuffer(coordsBuffer),
+    m_center(center),
+    m_size(size)
+{
+}
+
+void DrawQueueItemGroundShadow::draw()
+{
+    if (!m_coordsBuffer)
+        return;
+
+    const float scaleX = m_size.width() / kShadowBaseDiameter;
+    const float scaleY = m_size.height() / kShadowBaseDiameter;
+    if (scaleX <= 0.f || scaleY <= 0.f)
+        return;
+
+    g_painter->pushTransformMatrix();
+    g_painter->scale(scaleX, scaleY);
+    g_painter->translate(m_center.x, m_center.y);
+    g_painter->setColor(m_color);
+    g_painter->drawFillCoords(*m_coordsBuffer);
+    g_painter->popTransformMatrix();
+}
 
 void DrawQueueItemTextureCoords::draw()
 {
@@ -193,6 +250,14 @@ void DrawQueueConditionMark::end(DrawQueue* queue)
             g_painter->drawTexturedRect(texture->m_dest, texture->m_texture, texture->m_src);
     }
     g_painter->resetShaderProgram();
+}
+
+void DrawQueue::addGroundShadow(const PointF& center, const SizeF& size, const Color& color)
+{
+    if (size.width() <= 0.f || size.height() <= 0.f)
+        return;
+
+    m_queue.push_back(new DrawQueueItemGroundShadow(groundShadowCoords(), center, size, color));
 }
 
 void DrawQueue::setFrameBuffer(const Rect& dest, const Size& size, const Rect& src)

--- a/src/framework/graphics/drawqueue.h
+++ b/src/framework/graphics/drawqueue.h
@@ -2,6 +2,7 @@
 #define DRAWQUEUE_H
 
 #include <vector>
+#include <memory>
 #include <framework/graphics/declarations.h>
 #include <framework/graphics/coordsbuffer.h>
 #include <framework/graphics/paintershaderprogram.h>
@@ -9,6 +10,8 @@
 #include <framework/graphics/colorarray.h>
 #include <framework/graphics/deptharray.h>
 #include <framework/ui/uiwidget.h>
+#include <framework/util/point.h>
+#include <framework/util/size.h>
 
 class DrawQueue;
 struct DrawQueueItem;
@@ -106,6 +109,16 @@ struct DrawQueueItemFillCoords : public DrawQueueItem {
     bool cache();
 
     CoordsBuffer m_coordsBuffer;
+};
+
+struct DrawQueueItemGroundShadow : public DrawQueueItem {
+    DrawQueueItemGroundShadow(const std::shared_ptr<CoordsBuffer>& coordsBuffer, const PointF& center, const SizeF& size, const Color& color);
+
+    void draw() override;
+
+    std::shared_ptr<CoordsBuffer> m_coordsBuffer;
+    PointF m_center;
+    SizeF m_size;
 };
 
 struct DrawQueueItemText : public DrawQueueItem {
@@ -229,6 +242,7 @@ public:
     {
         m_queue.push_back(new DrawQueueItemFillCoords(coords, color));
     }
+    void addGroundShadow(const PointF& center, const SizeF& size, const Color& color = Color::white);
     void addClearRect(const Rect& dest, const Color& color = Color::white)
     {
         m_queue.push_back(new DrawQueueItemClearRect(dest, color));


### PR DESCRIPTION
## Summary
- add a reusable ground shadow draw queue item that shares a cached ellipse buffer for batching
- render a semi-transparent creature shadow before the outfit, scaling opacity and size with the creature footprint

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dab387fec883308a2b87633ce7426d